### PR TITLE
Add Ki recovery from eKi and fix OPC return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Generate your Ki secret keys and grab the OP and Transport keys from your carrie
 - [Description](#description)
 - [Usage](#usage)
 - [Installation](#installation)
+- [Testing](#testing)
 - [Support](#support)
 - [Contributing](#contributing)
 
@@ -123,6 +124,14 @@ $ python setup.py install
 NOTE: You may want to install the dependencies in advance, if you haven't yet.
 ```
 $ pip install -r requirements.txt
+```
+
+## Testing
+
+Run the test suite with:
+
+```
+$ python -m unittest discover -s tests
 ```
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ print (ki)
 # EBD77DF6CFF949448ACF82B8FE4E59E3
 print (kiopcgenerator.gen_opc(op, ki))
 # 33244F04A86408A53110D1FCAFD04288
-print (kiopcgenerator.gen_eki(transport, ki))
+eki = kiopcgenerator.gen_eki(transport, ki)
+print (eki)
 # 8FAC9FE22D306EA4CB86279B3473D8CB
 print (kiopcgenerator.gen_opc_eki(op, transport, ki))
 # {'KI': 'EBD77DF6CFF949448ACF82B8FE4E59E3', 'eKI': '8FAC9FE22D306EA4CB86279B3473D8CB', 'OPC': '33244F04A86408A53110D1FCAFD04288'}

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Options:
   -o OP, --op=OP              32 char OP key
   -t TRANS, --transport=TRANS 32 char Transport key
   -k KI, --ki=KI              Optional 32 char Ki key (to avoid random generation)
+  -e EKI, --eki=EKI           32 char eKI key (to recover Ki)
 
 $ kiopcgen  -o D7DECB1F50404CC29ECBF989FE73AFC5 -t 2257CC6E9746434B89F346F0276CCAEC
 {'KI': '780E6AC95A2E43449C15BDCDD0450982',
@@ -51,6 +52,13 @@ $ kiopcgen -o D7DECB1F50404CC29ECBF989FE73AFC5 -t 2257CC6E9746434B89F346F0276CCA
 {'KI': '8978B79E7C104F678FA5C336509DB188',
  'OPC': '6F2E82855DEE7C893CB1F7A72FD08B57',
  'eKI': 'FBE8C170F6A5C6C257E5324719674818'}
+
+Or recover Ki from an encrypted eKi:
+
+$ kiopcgen -o D7DECB1F50404CC29ECBF989FE73AFC5 -t 2257CC6E9746434B89F346F0276CCAEC -e 4601138387FCF7D666ED24BBB3EE37B8
+{'KI': '780E6AC95A2E43449C15BDCDD0450982',
+ 'OPC': '2274B84B8043105A28AABBE53EF1D014',
+ 'eKI': '4601138387FCF7D666ED24BBB3EE37B8'}
 ```
 
 Or import the kiopcgenerator module to use in your scripts
@@ -71,6 +79,10 @@ print (kiopcgenerator.gen_opc(op, ki))
 print (kiopcgenerator.gen_eki(transport, ki))
 # 8FAC9FE22D306EA4CB86279B3473D8CB
 print (kiopcgenerator.gen_opc_eki(op, transport, ki))
+# {'KI': 'EBD77DF6CFF949448ACF82B8FE4E59E3', 'eKI': '8FAC9FE22D306EA4CB86279B3473D8CB', 'OPC': '33244F04A86408A53110D1FCAFD04288'}
+
+# Recover Ki from eKi
+print (kiopcgenerator.recover_ki(op, transport, eki))
 # {'KI': 'EBD77DF6CFF949448ACF82B8FE4E59E3', 'eKI': '8FAC9FE22D306EA4CB86279B3473D8CB', 'OPC': '33244F04A86408A53110D1FCAFD04288'}
 ```
 

--- a/kiopcgen
+++ b/kiopcgen
@@ -17,9 +17,14 @@ parser = OptionParser()
 parser.add_option("-o", "--op", dest="op", help="32 char OP key")
 parser.add_option("-t", "--transport", dest="trans", help="32 char Transport key")
 parser.add_option("-k", "--ki", dest="ki", help="Optional 32 char Ki key (to avoid random generation)")
+parser.add_option("-e", "--eki", dest="eki", help="32 char eKI key (to recover Ki)")
 (options, args) = parser.parse_args()
 
-if options.op and options.trans:
+if options.eki and options.trans and options.op:
+    result = kiopcgenerator.recover_ki(options.op, options.trans, options.eki)
+    pprint.pprint(result)
+    sys.exit(0)
+elif options.op and options.trans:
     if not options.ki:
         options.ki = kiopcgenerator.gen_ki()
 

--- a/kiopcgenerator/lib.py
+++ b/kiopcgenerator/lib.py
@@ -45,7 +45,7 @@ class AuChss:
         aes_crypt = AES.new(ki, mode=AES.MODE_CBC, IV=iv)
         data = op
         o_pc = self._xor_str(data, aes_crypt.encrypt(data))
-        return binascii.hexlify(o_pc)
+        return binascii.hexlify(o_pc).decode('utf-8')
 
     def _xor_str(self, s, t):
         """xor two strings together"""

--- a/kiopcgenerator/lib.py
+++ b/kiopcgenerator/lib.py
@@ -79,11 +79,30 @@ def gen_opc(op, ki):
     return hss.calc_opc_hex(ki, op).upper()
 
 
+def aes_128_cbc_decrypt(key, ciphertext):
+    """
+    implements aes 128b decryption with cbc.
+    """
+    keyb = binascii.unhexlify(key)
+    ciphertextb = binascii.unhexlify(ciphertext)
+    decryptor = AES.new(keyb, AES.MODE_CBC, IV=IV)
+    plaintext = decryptor.decrypt(ciphertextb)
+    return plaintext.hex().upper()
+
+
 def gen_eki(transport, ki):
     """
     generates eKI based on ki and transport key
     """
     return aes_128_cbc_encrypt(transport, ki)
+
+
+def recover_ki(op, transport, eki):
+    """
+    recovers ki from eKI and generates opc using the transport key and op
+    """
+    ki = aes_128_cbc_decrypt(transport, eki)
+    return {"KI": ki, "OPC": gen_opc(op, ki), "eKI": eki}
 
 
 def gen_opc_eki(op, transport, ki):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,38 @@
+import ast
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "kiopcgen"
+
+# Known vector taken from the README usage example.
+OP = "D7DECB1F50404CC29ECBF989FE73AFC5"
+TRANSPORT = "2257CC6E9746434B89F346F0276CCAEC"
+KI = "780E6AC95A2E43449C15BDCDD0450982"
+OPC = "2274B84B8043105A28AABBE53EF1D014"
+EKI = "4601138387FCF7D666ED24BBB3EE37B8"
+
+
+class RecoverKiCliTest(unittest.TestCase):
+    def test_recovers_ki_from_eki(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "-o", OP,
+                "-t", TRANSPORT,
+                "-e", EKI,
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        self.assertEqual(
+            ast.literal_eval(result.stdout),
+            {"KI": KI, "OPC": OPC, "eKI": EKI},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,0 +1,87 @@
+import unittest
+
+import kiopcgenerator
+
+# Known vector taken from the README usage example.
+OP = "D7DECB1F50404CC29ECBF989FE73AFC5"
+TRANSPORT = "2257CC6E9746434B89F346F0276CCAEC"
+KI = "780E6AC95A2E43449C15BDCDD0450982"
+OPC = "2274B84B8043105A28AABBE53EF1D014"
+EKI = "4601138387FCF7D666ED24BBB3EE37B8"
+
+
+class GenOpcTest(unittest.TestCase):
+    def test_known_vector(self):
+        self.assertEqual(kiopcgenerator.gen_opc(OP, KI), OPC)
+
+    def test_invalid_hex_raises(self):
+        with self.assertRaises(ValueError):
+            kiopcgenerator.gen_opc("ZZ", KI)
+
+    def test_invalid_key_length_raises(self):
+        with self.assertRaises(ValueError):
+            kiopcgenerator.gen_opc(OP, "AABB")
+
+
+class GenEkiTest(unittest.TestCase):
+    def test_known_vector(self):
+        self.assertEqual(kiopcgenerator.gen_eki(TRANSPORT, KI), EKI)
+
+    def test_invalid_ki_hex_raises(self):
+        with self.assertRaises(ValueError):
+            kiopcgenerator.gen_eki(TRANSPORT, "ZZ")
+
+    def test_invalid_ki_length_raises(self):
+        with self.assertRaises(ValueError):
+            kiopcgenerator.gen_eki(TRANSPORT, "AABB")
+
+    def test_invalid_transport_hex_raises(self):
+        with self.assertRaises(ValueError):
+            kiopcgenerator.gen_eki("ZZ", KI)
+
+    def test_invalid_transport_length_raises(self):
+        with self.assertRaises(ValueError):
+            kiopcgenerator.gen_eki("AABB", KI)
+
+
+class RecoverKiTest(unittest.TestCase):
+    def test_known_vector(self):
+        self.assertEqual(
+            kiopcgenerator.recover_ki(OP, TRANSPORT, EKI),
+            {"KI": KI, "OPC": OPC, "eKI": EKI},
+        )
+
+    def test_round_trip_with_random_ki(self):
+        ki = kiopcgenerator.gen_ki()
+        eki = kiopcgenerator.gen_eki(TRANSPORT, ki)
+        recovered = kiopcgenerator.recover_ki(OP, TRANSPORT, eki)
+        self.assertEqual(recovered["KI"], ki)
+        self.assertEqual(recovered["OPC"], kiopcgenerator.gen_opc(OP, ki))
+
+    def test_invalid_eki_hex_raises(self):
+        with self.assertRaises(ValueError):
+            kiopcgenerator.recover_ki(OP, TRANSPORT, "ZZ")
+
+    def test_invalid_eki_length_raises(self):
+        with self.assertRaises(ValueError):
+            kiopcgenerator.recover_ki(OP, TRANSPORT, "AABB")
+
+    def test_invalid_transport_hex_raises(self):
+        with self.assertRaises(ValueError):
+            kiopcgenerator.recover_ki(OP, "ZZ", EKI)
+
+    def test_invalid_transport_length_raises(self):
+        with self.assertRaises(ValueError):
+            kiopcgenerator.recover_ki(OP, "AABB", EKI)
+
+    def test_invalid_op_hex_raises(self):
+        with self.assertRaises(ValueError):
+            kiopcgenerator.recover_ki("ZZ", TRANSPORT, EKI)
+
+    def test_invalid_op_length_raises(self):
+        with self.assertRaises(ValueError):
+            kiopcgenerator.recover_ki("AABB", TRANSPORT, EKI)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two changes:

1. Fix: binascii.hexlify() returns bytes in Python 3, causing OPC values to be bytes instead of strings. This made dict output inconsistent.
3. Feature: Added aes_128_cbc_decrypt() and recover_ki() to reverse eKi encryption, plus a -e/--eki CLI flag to recover Ki (with OPC and eKi) from an encrypted triplet given the OP and Transport Key.

**Usage:**
``` 
kiopcgen -o <OP> -t <TransportKey> -e <eKi>
```

At [C3GSM](https://c3gsm.de/), we regularly order eSIMs and have this problem. We're using this code to generate eKi from Ki and also use it for the OPc values. It felt fair to upstream this back to you <3