### PR TITLE
fix(kiopcgen): use portable python3 shebang

### DIFF
--- a/kiopcgen
+++ b/kiopcgen
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # vim: ts=4
 ###


### PR DESCRIPTION
/usr/bin/python is absent on many distros that ship only python3 (e.g. Debian, Fedora without python-unversioned-command), so the script failed to launch. Point at python3 via env instead.