### PR TITLE
Docs: Modernize installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,25 +76,6 @@ print (kiopcgenerator.gen_opc_eki(op, transport, ki))
 
 ## Installation
 
-Before install this you need to setup below dependency:
-
-```
-For Python 3.x
-$ sudo apt-get install python3-dev
-
-For Python 3.4
-$ sudo apt-get install python3.4-dev
-
-For Python 3.6.x
-$ sudo apt-get install python3.6-dev
-
-For Python 3.7
-$ sudo apt-get install python3.7-dev
-
-For Python 3.8
-$ sudo apt-get install python3.8-dev
-```
-
 Using PyPI repository
 
 ```

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ pip install git+https://github.com/PodgroupConnectivity/kiopcgenerator#egg=kio
 From source code
 
 ```
-$ python setup.py install
+$ pip install .
 ```
 
 NOTE: You may want to install the dependencies in advance, if you haven't yet.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 # Inside of setup.cfg
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
     keywords=['python', 'sim', 'simcard', 'telecoms'],
     version="0.1.4",
     license="GPLv3",
-    setup_requies=['wheel'],
     install_requires=[
         'pycrypto'
     ],


### PR DESCRIPTION
This contains various improvements (see individual commits for details) but the TL;DR is: The direct call to setup.py is deprecated and should be replaced with `pip install .` instead and with the change from PR #16 to pycrytodome the dependency to `wheel` and development headers are no longer needed. 